### PR TITLE
Fix issues around scrolling crashing

### DIFF
--- a/oBaseVisComponent.cpp
+++ b/oBaseVisComponent.cpp
@@ -596,8 +596,8 @@ qdim oBaseVisComponent::getVertStepSize(void) {
 // window was scrolled
 void oBaseVisComponent::evWindowScrolled(qdim pNewX, qdim pNewY) {
 	if ((mHorzScrollPos != pNewX) || (mVertScrollPos != pNewY)) {
-		WNDsetScrollPos(mHWnd, SB_HORZ, pNewX, qfalse);
-		WNDsetScrollPos(mHWnd, SB_VERT, pNewY, qfalse);
+		WNDsetScrollPos(mHWnd, SB_HORZ, pNewX, qtrue);
+		WNDsetScrollPos(mHWnd, SB_VERT, pNewY, qtrue);
 
 		// we may not need to do this..
 		WNDscrollWindow(mHWnd, mHorzScrollPos - pNewX, mVertScrollPos - pNewY);

--- a/oDrawingCanvas.cpp
+++ b/oDrawingCanvas.cpp
@@ -98,7 +98,7 @@ void oDrawingCanvas::setTextSpec(GDItextSpecStruct pSpec) {
 	HFONT lvOldFont = GDIselectObject(mHDC, lvNewFont);
 
 	if (mTextFont != 0) {
-		// save to delete the old selected font now that we've created a new one
+		// safe to delete the old selected font now that we've created a new one
 		GDIdeleteObject(mTextFont);
 	}
 	mTextFont = lvNewFont;
@@ -663,6 +663,8 @@ void oDrawingCanvas::drawLine(qpoint pFrom, qpoint pTo, qdim pWidth, qcol pCol, 
 
 	GDIsetTextColor(mHDC, oldCol);
 	GDIselectObject(mHDC, oldPen);
+
+	GDIdeleteObject(newPen); // and clean up...
 };
 
 // fills a rectangle using our standard pattern brush


### PR DESCRIPTION
This is a fix related to a crash issue in our widgets library. Scrolling resulted in new drawing actions that resulted in a memory leak that would eventually crash on windows.