### PR TITLE
Add automatic clang-format checks on commit

### DIFF
--- a/.github/workflows/scripts/clang_format.sh
+++ b/.github/workflows/scripts/clang_format.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This script runs clang-format and fixes copyright headers on all relevant files in the repo.
+# This is the primary script responsible for fixing style violations.
+
+set -uo pipefail
+IFS=$'\n\t'
+
+CLANG_FORMAT_FILE_EXTS=(".c" ".h" ".cpp" ".hpp" ".cc" ".hh" ".cxx" ".m" ".mm" ".inc" ".java" ".glsl")
+
+# Loops through all text files tracked by Git.
+git grep -zIl '' |
+while IFS= read -rd '' f; do
+    # Exclude 3rd party files.
+    if [[ "$f" == "hooks"* ]]; then
+        continue
+    elif [[ "$f" == "stb"* ]]; then
+        continue
+    fi
+    for extension in ${CLANG_FORMAT_FILE_EXTS[@]}; do
+        if [[ "$f" == *"$extension" ]]; then
+            # Run clang-format.
+            clang-format -i "$f"
+        fi
+    done
+done
+
+git diff > patch.patch
+
+# If no patch has been generated all is OK, clean up, and exit.
+if [ ! -s patch.patch ] ; then
+    printf "Files in this commit comply with the clang-format style rules.\n"
+    rm -f patch.patch
+    exit 0
+fi
+
+# A patch has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the formatting rules:\n\n"
+cat patch.patch
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+rm -f patch.patch
+exit 1

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,18 @@
+name: 📊 Static Checks
+on: [push, pull_request]
+
+jobs:
+  static-checks:
+    name: Formatting (clang-format)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -qq dos2unix recode clang-format
+
+      - name: Style checks via clang-format (clang_format.sh)
+        run: |
+          bash ./.github/workflows/scripts/clang_format.sh


### PR DESCRIPTION
Run clang format on Githubs CI to verify a commits formatting.